### PR TITLE
Add pytest matrix workflow

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -7,21 +7,28 @@ on:
       local_package_name:
         required: true
         type: string
-      python_version:
+      python_versions:
         required: false
-        default: '3.9'
+        default: >-
+          ["3.8", "3.9", "3.10"]
+        description: JSON string containing the list of python versions to test
         type: string
 
 jobs:
   pytest:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python_version: ${{ fromJson(inputs.python_versions) }}
+
     steps:
       - uses: actions/checkout@v3
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
           mamba-version: "*"
-          python-version: ${{ inputs.python_version }}
+          python-version: ${{ matrix.python_version }}
           activate-environment: ${{ inputs.conda_env_name }}
           environment-file: environment.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * [`reusable-relese-checklist-comment.yml`](.github/workflows/reusable-release-checklist-comment.yml) reusable workflow to
   add a comment to PRs with a release checklist for developers and reviewers
 
+### Changed
+* [`reusable-pytest.yml`](.github/workflows/reusable-pytest.yml) now accepts (only) a JSON list of python version strings
+  and will setup a matrix of test jobs for multiple python versions. `python_version` usage has changed from
+  ```yaml
+    python_version: "3.9"            # Optional; default shown  
+  ```
+  to 
+  ```yaml
+      # Optional; default shown
+      python_version: >-
+        ["3.8", "3.9", "3.10"]
+  ```
+  Note: A single python version can be specified like `["3.9"]`.
+
 ### Removed
 * Removed support for secret scanning with `gitleaks-action`, which now requires a paid license to use the latest version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   to 
   ```yaml
       # Optional; default shown
-      python_version: >-
+      python_versions: >-
         ["3.8", "3.9", "3.10"]
   ```
   Note: A single python version can be specified like `["3.9"]`.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ jobs:
       conda_env_name: hyp3-plugin      # Required; conda environment name to activate
       # Optional; default shown
       python_version: >-
-        ["3.8", "3.9", "3.10"]          
+        ["3.8", "3.9", "3.10"]
 ```
 
 to test your Python package and produce a coverage report for. Importantly, `python_version` *must* be a valid JSON string

--- a/README.md
+++ b/README.md
@@ -241,10 +241,13 @@ jobs:
     with:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
       conda_env_name: hyp3-plugin      # Required; conda environment name to activate
-      python_version: '3.9'            # Optional; default shown
+      # Optional; default shown
+      python_version: >-
+        ["3.8", "3.9", "3.10"]          
 ```
 
-to test your Python package and produce a coverage report for.
+to test your Python package and produce a coverage report for. Importantly, `python_version` *must* be a valid JSON string
+containing a list of python version strings.
 
 ### [`reusable-release.yml`](./.github/workflows/reusable-release.yml)
 

--- a/README.md
+++ b/README.md
@@ -242,11 +242,11 @@ jobs:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
       conda_env_name: hyp3-plugin      # Required; conda environment name to activate
       # Optional; default shown
-      python_version: >-
+      python_versions: >-
         ["3.8", "3.9", "3.10"]
 ```
 
-to test your Python package and produce a coverage report for. Importantly, `python_version` *must* be a valid JSON string
+to test your Python package and produce a coverage report for. Importantly, `python_versions` *must* be a valid JSON string
 containing a list of python version strings.
 
 ### [`reusable-release.yml`](./.github/workflows/reusable-release.yml)


### PR DESCRIPTION
This updates the pytest workflow to accept JSON input so that a matrix of python versions can be specified. Usage looks like:
```yaml
  call-pytest-workflow:
    uses: ASFHyP3/actions/.github/workflows/reusable-pytest-matrix.yml@pytest-matrix
    with:
      local_package_name: hyp3_ci
      conda_env_name: hyp3-ci
      python_versions: >-
        ["3.8", "3.10"]
```
Notably, this chances the python version input from a string like `"3.8"` to a valid JSON list of strings and so is a breaking change.

This will require these PRs before we can release it as `asf-tools`, `bullets`, `hyp3-autorift`, and `hyp3-gamma` are all pointing at `@main` currently:
- [x] ASFHyP3/asf-tools#138
- [x] ASFHyP3/bullets#18
- [x] ASFHyP3/hyp3-autorift#163
- [x] ASFHyP3/hyp3-gamma#409

So I'm going to leave as draft for now until those are all done.