### PR TITLE
Fix workflow syntax for reusable docker workflows

### DIFF
--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -67,7 +67,7 @@ jobs:
           dst: ${{ inputs.ecr_registry }}/${{ github.event.repository.name }}:test
 
       - name: Add latest tag
-        if: github.ref == format('refs/heads/{0}', inputs.develop_branch)
+        if: github.ref == format('refs/heads/{0}', inputs.release_branch)
         uses: akhilerm/tag-push-action@v1.0.0
         with:
           src: ${{ inputs.ecr_registry }}/${{ github.event.repository.name }}:${{ inputs.version_tag }}

--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -60,14 +60,14 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Add test tag
-        if: github.ref == format('refs/heads/{}', inputs.develop_branch)
+        if: github.ref == format('refs/heads/{0}', inputs.develop_branch)
         uses: akhilerm/tag-push-action@v1.0.0
         with:
           src: ${{ inputs.ecr_registry }}/${{ github.event.repository.name }}:${{ inputs.version_tag }}
           dst: ${{ inputs.ecr_registry }}/${{ github.event.repository.name }}:test
 
       - name: Add latest tag
-        if: github.ref == format('refs/heads/{}', inputs.develop_branch)
+        if: github.ref == format('refs/heads/{0}', inputs.develop_branch)
         uses: akhilerm/tag-push-action@v1.0.0
         with:
           src: ${{ inputs.ecr_registry }}/${{ github.event.repository.name }}:${{ inputs.version_tag }}

--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -31,11 +31,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Dump Context
-        run: |
-          echo '${{ toJSON(github) }}'
-          echo '${{ github.ref }}'
-
       - name: set environment variables
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV

--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -32,13 +32,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Dump Context
-        shell: bash -l {0}
         run: |
           echo '${{ toJSON(github) }}'
           echo '${{ github.ref }}'
 
       - name: set environment variables
-        shell: bash -l {0}
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 

--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -60,14 +60,14 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Add test tag
-        if: github.ref == 'refs/heads/${{ inputs.develop_branch }}'
+        if: github.ref == format('refs/heads/{}', inputs.develop_branch)
         uses: akhilerm/tag-push-action@v1.0.0
         with:
           src: ${{ inputs.ecr_registry }}/${{ github.event.repository.name }}:${{ inputs.version_tag }}
           dst: ${{ inputs.ecr_registry }}/${{ github.event.repository.name }}:test
 
       - name: Add latest tag
-        if: github.ref == 'refs/heads/${{ inputs.release_branch }}'
+        if: github.ref == format('refs/heads/{}', inputs.develop_branch)
         uses: akhilerm/tag-push-action@v1.0.0
         with:
           src: ${{ inputs.ecr_registry }}/${{ github.event.repository.name }}:${{ inputs.version_tag }}

--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -31,6 +31,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Dump Context
+        shell: bash -l {0}
+        run: |
+          echo '${{ toJSON(github) }}'
+          echo '${{ github.ref }}'
+
       - name: set environment variables
         shell: bash -l {0}
         run: |

--- a/.github/workflows/reusable-docker-ghcr.yml
+++ b/.github/workflows/reusable-docker-ghcr.yml
@@ -58,14 +58,14 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Add test tag
-        if: github.ref == 'refs/heads/${{ inputs.develop_branch }}'
+        if: github.ref == format('refs/heads/{0}', inputs.develop_branch)
         uses: akhilerm/tag-push-action@v1.0.0
         with:
           src: ghcr.io/${{ env.REPO }}:${{ inputs.version_tag }}
           dst: ghcr.io/${{ env.REPO }}:test
 
       - name: Add latest tag
-        if: github.ref == 'refs/heads/${{ inputs.release_branch }}'
+        if: github.ref == format('refs/heads/{0}', inputs.release_branch)
         uses: akhilerm/tag-push-action@v1.0.0
         with:
           src: ghcr.io/${{ env.REPO }}:${{ inputs.version_tag }}


### PR DESCRIPTION
GitHub actions implicitly evaluates `if:` conditions as expressions (i.e., inside a `${{}}` context).
https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions

So, 
```yaml
if: github.ref == 'refs/head/develop`
```
is really
```yaml
if: ${{ github.ref == 'refs/head/develop` }}
```

In our docker reusable workflows we had a nested-expression, effectively:
```yaml
if: ${{ github.ref == 'refs/heads/${{ inputs.develop_branch }}' }}
```
which, when evaluated ends up looking like:
```yaml
if: 'github.ref == refs/heads/develop'
```
which causes the if statement to evaluate the truthy-ness of the string `github.ref == refs/heads/develop` instead of evaluating the expression we expected. 

The fix is to use the [`format()` function](https://docs.github.com/en/actions/learn-github-actions/expressions#format) to create the comparison string instead of trying to nest expressions. 