### PR TITLE
make sure tags are available for the docker build

### DIFF
--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -30,9 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: set environment variables
         run: |
+          git fetch origin +refs/tags/*:refs/tags/*
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable-docker-ghcr.yml
+++ b/.github/workflows/reusable-docker-ghcr.yml
@@ -25,10 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: set environment variables
-        shell: bash -l {0}
         run: |
+          git fetch origin +refs/tags/*:refs/tags/*
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
These docker workflows are no longer providing the right source package version inside the containers.

Previously, I removed the conda environment setup from the dockerize workflow since it's only used to provide a version number for tagging the container (that logic was moved to the `reusable-version-info.yml` workflow), and we have other workflows that also need the version number. Likewise, the full fetch of the git repo and tags appeared to no longer be needed and were removed.

However, when the docker container is built, we copy in the package source, and `pip` install it inside the container. `setuptools_scm` still needs the git tags to correctly provide the version number inside the container. 

An alt. approach would be to actually build the package distribution outside the container and just copy that in, but that step would need to always be performed locally prior to building the container and we'd need to ensure the copied distribution matches the version we expect -- we could do that by always pushing to PyPI and pip installing that version. 

We've historically not pushed to PyPI because we don't expect anyone but ourselves to run this code and so there's no need to distribute to the world. Currently, there's no other reason to not push to PyPI for any of our `hyp3-` repos as they are all public and open source. 