### PR TITLE
Pin gitleaks to v1 as v2 needs a paid API token

### DIFF
--- a/.github/workflows/reusable-secrets-analysis.yml
+++ b/.github/workflows/reusable-secrets-analysis.yml
@@ -10,7 +10,7 @@ jobs:
           fetch-depth: 0
 
       - name: Scan for secrets with gitleaks
-        uses: zricethezav/gitleaks-action@master
+        uses: zricethezav/gitleaks-action@v1
 
   trufflehog:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-secrets-analysis.yml
+++ b/.github/workflows/reusable-secrets-analysis.yml
@@ -10,7 +10,7 @@ jobs:
           fetch-depth: 0
 
       - name: Scan for secrets with gitleaks
-        uses: gitleaks/gitleaks-action@v1
+        uses: gitleaks/gitleaks-action@v1.6.0
 
   trufflehog:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-secrets-analysis.yml
+++ b/.github/workflows/reusable-secrets-analysis.yml
@@ -10,7 +10,7 @@ jobs:
           fetch-depth: 0
 
       - name: Scan for secrets with gitleaks
-        uses: zricethezav/gitleaks-action@v1
+        uses: gitleaks/gitleaks-action@v1
 
   trufflehog:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,4 +4,4 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@pin-gitleaks
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,26 +3,5 @@ name: Static analysis
 on: push
 
 jobs:
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Scan for secrets with gitleaks
-        uses: zricethezav/gitleaks-action@master
-
-
-  trufflehog:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.9
-
-      - uses: ASFHyP3/actions/trufflehog@main
+  call-secrets-analysis-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@pin-gitleaks


### PR DESCRIPTION
See: https://github.com/gitleaks/gitleaks-action#-announcement

