### PR TITLE
Fix coverage report in reusable pytest and no-deps install

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Pytest in conda environment
         shell: bash -l {0}
         run: |
-          python -m pip install .[develop]
-          pytest --cov=${{ inputs.local_page_name }}
+          python -m pip install --no-deps .
+          pytest --cov=${{ inputs.local_package_name }}


### PR DESCRIPTION
This:
* Fixes the name of the `local_package_name` input: https://github.com/ASFHyP3/actions/compare/fix-reusable-pytest?expand=1#diff-1da8ce67b1810b20473f80b736705311db062337ce3753ba9cd5428c8fdc02ccL7
* drops the `[develop]` extra from the pip install (more below)
* adds the `--no-deps` flag to the pip install command since all dependencies should already be in the conda environment. This will prevent pip from changing the conda provided ones (pip won't try and install any packages at all). See: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-deps

--- 

Since all testing packages are in the conda environment, pip installing `.[develop]` and `.` are functionally equivalent. If the `[develop]` extra is provided then, in `asf_tools` for example, pip will look at these `extras_require` dependencies as well and ensure they are also installed in the env. 

https://github.com/ASFHyP3/asf-tools/blob/develop/setup.py#L48-L56

Removing this here, since we're explicitly using conda environments should have zero effect and especially if we add the `--no-deps` flag. It will, however, make this action more universal as we aren't requiring packages to provide a `[develop]` extra (a team convention)

