### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners will be requested for review when someone opens a pull request.
+*       @ASFHyP3/tools

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,16 @@
+name: Changelog updated?
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+      - develop
+jobs:
+  call-changelog-check-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@main
+    secrets:
+      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -1,0 +1,15 @@
+name: Is PR labeled?
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+
+jobs:
+  call-labeled-pr-check-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Write release and finish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  call-release-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@main
+    with:
+      release_prefix: Actions
+    secrets:
+      USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Pytest in conda environment
         shell: bash -l {0}
         run: |
-          python -m pip install .[develop]
-          pytest --cov=${{ inputs.local_page_name }}
+          python -m pip install --no-deps .
+          pytest --cov=${{ inputs.local_package_name }}

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,0 +1,12 @@
+name: Tag version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  call-bump-version-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@main
+    secrets:
+      USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,27 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   tag for a repository based on Pull Request labels using bump2version
 * [`reusable-changelog-check.yml`](.github/workflows/reusable-changelog-check.yml) reusable workflow to ensure the
   changelog has been updated
+* [`reusable-docker-ecr.yml`](./.github/workflows/reusable-docker-ecr.yml) reusable workflow to build a Docker image
+  from the `Dockerfile` in the repository root and pushes it to the [Amazon Elastic Container Registry](https://aws.amazon.com/ecr/)
+* [`reusable-docker-ghcr.yml`](./.github/workflows/reusable-docker-ghcr.yml) reusable workflow to build a Docker image
+  from the `Dockerfile` in the repository root and pushes it to the [GitHub Container Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+* [`reusable-flake8.yml`](./.github/workflows/reusable-flake8.yml) eusable workflow to enforce ASFHyP3's Python
+  style guide with [flake8](https://flake8.pycqa.org/en/latest/)
 * [`reusable-labeled-pr-check.yml`](.github/workflows/reusable-labeled-pr-check.yml) reusable workflow to ensure a Pull
   Request has been appropriately labeled for a release
+* [`reusable-pytest.yml`](./.github/workflows/reusable-pytest.yml) reusable workflow to runs [pytest](https://docs.pytest.org/en/6.2.x/)
+  in the repository's conda environment
 * [`reusable-release.yml`](.github/workflows/reusable-release.yml) reusable workflow to create a release from a
   `CHANGELOG.md` file and synchronize the release and development branches
 * [`reusable-secrets-analysis.yml`](.github/workflows/reusable-secrets-analysis.yml) reusable workflow to scan a PR for
   potentially committed secrets using [git-leaks](https://github.com/zricethezav/gitleaks)
   and [truffleHog](https://github.com/trufflesecurity/truffleHog)
+* [`reusable-version-info.yml`](./.github/workflows/reusable-version-info.yml) reusable workflow to outputs the
+  repository's Python package version number
 
 ### Deprecated
+
+These actions are being depreciated and will be removed in the next release:
 * The [bump-version action ](bump-version/README.md) in favor of the 
   [`reusable-bump-version.yml`](.github/workflows/reusable-bump-version.yml) reusable workflow
 * The [trufflehog action](trufflehog/README.md) in favor of the


### PR DESCRIPTION
I'd like the release the version all our repositories are using, pin them all to the released version, and then circle back to the dependabot updates.

Since we switched to a release workflow from just merging to `main`, the `main` branch is 34 commits ahead of `v0.1.0`. The full release PR can be seen here:
https://github.com/ASFHyP3/actions/compare/v0.1.0...develop