### PR TITLE
Rework setting output for Github Actions

### DIFF
--- a/.github/workflows/reusable-bump-version.yml
+++ b/.github/workflows/reusable-bump-version.yml
@@ -112,7 +112,6 @@ jobs:
       - name: Tag version
         if: env.BUMP_PART != 'bumpless'
         run: |
-          git fetch origin +refs/tags/*:refs/tags/*
           git config user.email ${{ inputs.email }}
           git config user.name ${{ inputs.user }}
           bump2version --current-version $(git describe --abbrev=0) --tag --tag-message "${TAG_MSG}" "${BUMP_PART}"

--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: set environment variables
         run: |
-          git fetch origin +refs/tags/*:refs/tags/*
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable-docker-ghcr.yml
+++ b/.github/workflows/reusable-docker-ghcr.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: set environment variables
         run: |
-          git fetch origin +refs/tags/*:refs/tags/*
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx

--- a/.github/workflows/reusable-git-object-name.yml
+++ b/.github/workflows/reusable-git-object-name.yml
@@ -19,6 +19,5 @@ jobs:
         id: set_outputs
         shell: bash -l {0}
         run: |
-          git fetch origin +refs/tags/*:refs/tags/*
           export SDIST_VERSION=$(git describe)
           echo "::set-output name=name::${SDIST_VERSION}"

--- a/.github/workflows/reusable-git-object-name.yml
+++ b/.github/workflows/reusable-git-object-name.yml
@@ -20,4 +20,4 @@ jobs:
         shell: bash -l {0}
         run: |
           export SDIST_VERSION=$(git describe)
-          echo "::set-output name=name::${SDIST_VERSION}"
+          echo "name=${SDIST_VERSION}" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-secrets-analysis.yml
+++ b/.github/workflows/reusable-secrets-analysis.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Scan for secrets with trufflehog
         shell: bash
         run: |
-          git fetch origin +refs/tags/*:refs/tags/*
           export LAST_TAG_HASH=$(git rev-list -1 $(git describe --abbrev=0))
           trufflehog --regex --entropy True --since_commit "${LAST_TAG_HASH}" \
               --exclude_paths .trufflehog.txt file://"${PWD}"

--- a/.github/workflows/reusable-version-info.yml
+++ b/.github/workflows/reusable-version-info.yml
@@ -39,5 +39,6 @@ jobs:
         shell: bash -l {0}
         run: |
           export SDIST_VERSION=$(python setup.py --version)
-          echo "::set-output name=version::${SDIST_VERSION}"
-          echo "::set-output name=version_tag::${SDIST_VERSION/+/_}"
+          echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT
+          echo "version_tag=${SDIST_VERSION/+/_}" >> $GITHUB_OUTPUT
+          echo "Version number: ${SDIST_VERSION}"

--- a/.github/workflows/reusable-version-info.yml
+++ b/.github/workflows/reusable-version-info.yml
@@ -38,7 +38,6 @@ jobs:
         id: set_outputs
         shell: bash -l {0}
         run: |
-          git fetch origin +refs/tags/*:refs/tags/*
           export SDIST_VERSION=$(python setup.py --version)
           echo "::set-output name=version::${SDIST_VERSION}"
           echo "::set-output name=version_tag::${SDIST_VERSION/+/_}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.6.0]
+
+### Fixed
+* All uses of the GitHub Action `set-output` command have been upgraded, due to
+  forthcoming [depreciation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
+
 ## [0.5.0]
 
 ### Added


### PR DESCRIPTION
The GitHub Actions `set-output` command [is depreciated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and leads to warnings like:
![image](https://user-images.githubusercontent.com/7882693/200489521-b6534128-3531-4739-803f-1c80db849f9f.png)

Also, we no longer need to explicitly fetch tags as that's done by default in [`actions/checkout@v3`](https://github.com/actions/checkout/blob/1f9a0c22da41e6ebfa534300ef656657ea2c6707/README.md#fetch-all-history-for-all-tags-and-branches) if `fetch-depth: 0` (we upgraded to v3 in #12), 