### PR TITLE
Handle lightweight tags in `reusable-git-object-name.yml`

### DIFF
--- a/.github/workflows/reusable-git-object-name.yml
+++ b/.github/workflows/reusable-git-object-name.yml
@@ -19,5 +19,5 @@ jobs:
         id: set_outputs
         shell: bash -l {0}
         run: |
-          export SDIST_VERSION=$(git describe)
+          export SDIST_VERSION=$(git describe --dirty --tags --long --match "*[0-9]*")
           echo "name=${SDIST_VERSION}" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.6.0]
 
+### Changed
+* [`reusable-git-object-name.yml`](.github/workflows/reusable-git-object-name.yml) now handles lightweight as well as
+  annotated tags
+
 ### Fixed
 * All uses of the GitHub Action `set-output` command have been upgraded, due to
   forthcoming [depreciation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ jobs:
 
 ### [`reusable-git-object-name.yml`](./.github/workflows/reusable-git-object-name.yml)
 
-Outputs the human-readable git object name from [`git describe`](https://git-scm.com/docs/git-describe) 
+Outputs the human-readable git object name from [`git describe --dirty --tags --long --match "*[0-9]*"`](https://git-scm.com/docs/git-describe)
 of the calling repository. Use like:
 
 ```yaml
@@ -173,7 +173,7 @@ jobs:
       - run: |
           echo "name: ${{ needs.call-git-object-name-workflow.outputs.name }}"
 ```
-and is intended to be paired with workflows like the `reusable-docker-ghcr.yml` workflow.
+This workflow is intended to be paired with workflows like the `reusable-docker-ghcr.yml` workflow.
 
 ### [`reusable-flake8.yml`](./.github/workflows/reusable-flake8.yml)
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,25 @@ jobs:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
 ```
 
+### [`reusable-flake8.yml`](./.github/workflows/reusable-flake8.yml)
+
+Runs [flake8](https://flake8.pycqa.org/en/latest/) to enforce ASFHyP3's Python style guide. Use like:
+
+```yaml
+name: Static analysis
+
+on: push
+
+jobs:
+  call-flake8-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.4.0
+    with:
+      local_package_names: hyp3_plugin  # Required; comma-seperated list of names that should be considered local to your application
+      excludes: hyp3_plugin/ugly.py     # Optional; comma-separated list of glob patterns to exclude from checks
+```
+
+to ensure the Python code is styled correctly.
+
 ### [`reusable-git-object-name.yml`](./.github/workflows/reusable-git-object-name.yml)
 
 Outputs the human-readable git object name from [`git describe --dirty --tags --long --match "*[0-9]*"`](https://git-scm.com/docs/git-describe)
@@ -174,25 +193,6 @@ jobs:
           echo "name: ${{ needs.call-git-object-name-workflow.outputs.name }}"
 ```
 This workflow is intended to be paired with workflows like the `reusable-docker-ghcr.yml` workflow.
-
-### [`reusable-flake8.yml`](./.github/workflows/reusable-flake8.yml)
-
-Runs [flake8](https://flake8.pycqa.org/en/latest/) to enforce ASFHyP3's Python style guide. Use like:
-
-```yaml
-name: Static analysis
-
-on: push
-
-jobs:
-  call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.4.0
-    with:
-      local_package_names: hyp3_plugin  # Required; comma-seperated list of names that should be considered local to your application
-      excludes: hyp3_plugin/ugly.py     # Optional; comma-separated list of glob patterns to exclude from checks
-```
-
-to ensure the Python code is styled correctly.
 
 ### [`reusable-labeled-pr-check.yml`](./.github/workflows/reusable-labeled-pr-check.yml)
 


### PR DESCRIPTION
Updates the reusable-git-object-name.yml to use [git describe --dirty --tags --long --match "*[0-9]*"](https://git-scm.com/docs/git-describe) to:
* handle light weight as well as annotated tags
*  be in line with the git describe command that setuptools_scm uses on [the back end](https://github.com/pypa/setuptools_scm/blob/main/src/setuptools_scm/git.py#L36-L44), which is what we're using to create our python package version numbers

Also, moves flake8 workflow above git-object-name to ensure they are alphabetized in the readme.

---
**Note:** This currently includes changes in these PRs, which should be reviewed and merged first:
- [x] #39 