### PR TITLE
Switch to using setuptools_scm to get version number

### DIFF
--- a/.github/workflows/reusable-version-info.yml
+++ b/.github/workflows/reusable-version-info.yml
@@ -15,7 +15,6 @@ on:
         value: ${{ jobs.version_info.outputs.version_tag }}
 
 
-
 jobs:
   version_info:
     runs-on: ubuntu-latest
@@ -38,7 +37,7 @@ jobs:
         id: set_outputs
         shell: bash -l {0}
         run: |
-          export SDIST_VERSION=$(python setup.py --version)
+          export SDIST_VERSION=$(python -m setuptools_scm)
           echo "version=${SDIST_VERSION}" >> $GITHUB_OUTPUT
           echo "version_tag=${SDIST_VERSION/+/_}" >> $GITHUB_OUTPUT
           echo "Version number: ${SDIST_VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.6.0]
 
 ### Changed
+* [`reusable-version-info.yml`](.github/workflows/reusable-version-info.yml) now uses `setuptools_scm`for generating
+  version numbers as the use of `setup.py` [is discouraged](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#setuppy-discouraged)
 * [`reusable-git-object-name.yml`](.github/workflows/reusable-git-object-name.yml) now handles lightweight as well as
   annotated tags
 

--- a/README.md
+++ b/README.md
@@ -327,8 +327,9 @@ to scan every push for secrets.
 
 ### [`reusable-version-info.yml`](./.github/workflows/reusable-version-info.yml)
 
-Outputs the version number of the calling repositories Python package by running `python setup.py --version` from the
-repository root. Requires an `environment.yml` file at the root of the calling repository specifying all the runtime
+Outputs the version number of the calling repositories Python package by running
+[`python -m setuptools_scm`](https://github.com/pypa/setuptools_scm#pyprojecttoml-usage) from the repository root.
+Requires an `environment.yml` file at the root of the calling repository specifying all the runtime
 dependencies needed. This workflow will additionally output a Docker tag compatible version number. Use like:
 
 ```yaml
@@ -350,7 +351,7 @@ jobs:
     with:
       conda_env_name: hyp3-plugin  # Required; conda environment name to activate
       python_version: '3.9'        # Optional; default shown
-  
+
   echo-version-info-outputs:
     needs: call-version-info-workflow
     runs-on: ubuntu-latest
@@ -359,4 +360,4 @@ jobs:
           echo "version: ${{ needs.call-version-info-workflow.outputs.version }}"
           echo "version tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}"
 ```
-and is intended to be paired with workflows like the `reusable-docker-ghcr.yml` workflow.
+This workflow is intended to be paired with workflows like the `reusable-docker-ghcr.yml` workflow.


### PR DESCRIPTION
The current version of this workflow relies on `setup.py --version` but the use of `setup.py` [is discouraged](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#setuppy-discouraged). 

This switches to using  [`python -m setuptools_scm`](https://github.com/pypa/setuptools_scm#pyprojecttoml-usage) for "modern" (`pyproject.toml` + `setuptools>=61`) python packages

---
**Note:** This currently includes changes in these PRs, which should be reviewed and merged first:
- [x] #39
- [x] #40