### PR TITLE
bump to v0.6.0 in prep for release

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,6 +11,6 @@ on:
       - develop
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.6.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.6.0
     with:
       release_prefix: Actions
     secrets:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,4 +4,4 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.6.0

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.6.0
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.6.0
     with:
       user: tools-bot                # Optional; default shown
       email: UAF-asf-apd@alaska.edu  # Optional; default shown
@@ -57,7 +57,7 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.6.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -87,13 +87,13 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
     with:
       conda_env_name: hyp3-plugin
 
   call-docker-ecr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.6.0
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       ecr_registry: 845172464411.dkr.ecr.us-west-2.amazonaws.com
@@ -128,13 +128,13 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
     with:
       conda_env_name: hyp3-plugin
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.6.0
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       release_branch: main     # Optional; default shown
@@ -155,7 +155,7 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.6.0
     with:
       local_package_names: hyp3_plugin  # Required; comma-seperated list of names that should be considered local to your application
       excludes: hyp3_plugin/ugly.py     # Optional; comma-separated list of glob patterns to exclude from checks
@@ -183,7 +183,7 @@ on:
 
 jobs:
   call-git-object-name-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.6.0
   
   echo-git-object-name-outputs:
     needs: call-git-object-name-workflow
@@ -213,7 +213,7 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.6.0
 ```
 to ensure a release label is included on any PR to `main`.
 
@@ -237,7 +237,7 @@ on:
 
 jobs:
   call-pytest-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.6.0
     with:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
       conda_env_name: hyp3-plugin      # Required; conda environment name to activate
@@ -267,7 +267,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.6.0
     with:
       release_prefix: HyP3-CI
       release_branch: main      # Optional; default shown
@@ -294,7 +294,7 @@ on:
   
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-relese-checklist-comment.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-relese-checklist-comment.yml@v0.6.0
     with:
       # optional; example shown
       additional_developer_items: '- [ ] If the step function code has changed, have you drained the job queue before merging?'
@@ -321,7 +321,7 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.6.0
 ```
 to scan every push for secrets.
 
@@ -347,7 +347,7 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
     with:
       conda_env_name: hyp3-plugin  # Required; conda environment name to activate
       python_version: '3.9'        # Optional; default shown


### PR DESCRIPTION
This updates all the workflows to use the new release, as well as all examples in the README. 

There's a window of time where this is merged and the readme will show a non-existent version until the next is released, so we should move #42 rapidly after this one.