### PR TITLE
Use micromamba instead of miniconda

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -23,8 +23,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: mamba-org/provision-with-micromamba@v14
-        extra-specs: |
-          python=${{ matrix.python_version }}
+        with:
+          extra-specs: |
+            python=${{ matrix.python_version }}
 
       - name: Pytest in conda environment
         shell: bash -l {0}

--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -1,9 +1,6 @@
 on:
   workflow_call:
     inputs:
-      conda_env_name:
-        required: true
-        type: string
       local_package_name:
         required: true
         type: string
@@ -25,12 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          mamba-version: "*"
-          python-version: ${{ matrix.python_version }}
-          activate-environment: ${{ inputs.conda_env_name }}
-          environment-file: environment.yml
+      - uses: mamba-org/provision-with-micromamba@v14
+        extra-specs: |
+          python=${{ matrix.python_version }}
 
       - name: Pytest in conda environment
         shell: bash -l {0}

--- a/.github/workflows/reusable-version-info.yml
+++ b/.github/workflows/reusable-version-info.yml
@@ -1,9 +1,6 @@
 on:
   workflow_call:
     inputs:
-      conda_env_name:
-        required: true
-        type: string
       python_version:
         required: false
         default: '3.9'
@@ -26,12 +23,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          mamba-version: "*"
-          python-version: ${{ inputs.python_version }}
-          activate-environment: ${{ inputs.conda_env_name }}
-          environment-file: environment.yml
+      - uses: mamba-org/provision-with-micromamba@v14
+        extra-specs: |
+          python=${{ inputs.python_version }}
 
       - name: set outputs
         id: set_outputs

--- a/.github/workflows/reusable-version-info.yml
+++ b/.github/workflows/reusable-version-info.yml
@@ -24,8 +24,9 @@ jobs:
           fetch-depth: 0
 
       - uses: mamba-org/provision-with-micromamba@v14
-        extra-specs: |
-          python=${{ inputs.python_version }}
+        with:
+          extra-specs: |
+            python=${{ inputs.python_version }}
 
       - name: set outputs
         id: set_outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.0]
+
+### Changed
+* `conda` environments are now provisioned with micromamba in all reusable workflows
+
 ## [0.6.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * `conda` environments are now provisioned with micromamba in all reusable workflows
+* [`reusable-pytest.yml`](.github/workflows/reusable-pytest.yml) and [`reusable-pytest.yml`](.github/workflows/reusable-version-info.yml)
+  no longer accept a `conda_env_name` input and will use the environment named in the calling repo's `environment.yml`
 
 ## [0.6.0]
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.6.0
     with:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
-      conda_env_name: hyp3-plugin      # Required; conda environment name to activate
       # Optional; default shown
       python_versions: >-
         ["3.8", "3.9", "3.10"]
@@ -349,7 +348,6 @@ jobs:
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
     with:
-      conda_env_name: hyp3-plugin  # Required; conda environment name to activate
       python_version: '3.9'        # Optional; default shown
 
   echo-version-info-outputs:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.7.0
     with:
       user: tools-bot                # Optional; default shown
       email: UAF-asf-apd@alaska.edu  # Optional; default shown
@@ -57,7 +57,7 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.7.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -87,13 +87,13 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.0
     with:
       conda_env_name: hyp3-plugin
 
   call-docker-ecr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.7.0
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       ecr_registry: 845172464411.dkr.ecr.us-west-2.amazonaws.com
@@ -128,13 +128,13 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.0
     with:
       conda_env_name: hyp3-plugin
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.7.0
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       release_branch: main     # Optional; default shown
@@ -155,7 +155,7 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.7.0
     with:
       local_package_names: hyp3_plugin  # Required; comma-seperated list of names that should be considered local to your application
       excludes: hyp3_plugin/ugly.py     # Optional; comma-separated list of glob patterns to exclude from checks
@@ -183,7 +183,7 @@ on:
 
 jobs:
   call-git-object-name-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.7.0
   
   echo-git-object-name-outputs:
     needs: call-git-object-name-workflow
@@ -213,7 +213,7 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.7.0
 ```
 to ensure a release label is included on any PR to `main`.
 
@@ -237,7 +237,7 @@ on:
 
 jobs:
   call-pytest-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.7.0
     with:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
       # Optional; default shown
@@ -266,7 +266,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.7.0
     with:
       release_prefix: HyP3-CI
       release_branch: main      # Optional; default shown
@@ -293,7 +293,7 @@ on:
   
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-relese-checklist-comment.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-relese-checklist-comment.yml@v0.7.0
     with:
       # optional; example shown
       additional_developer_items: '- [ ] If the step function code has changed, have you drained the job queue before merging?'
@@ -320,7 +320,7 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.7.0
 ```
 to scan every push for secrets.
 
@@ -346,7 +346,7 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.6.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.0
     with:
       python_version: '3.9'        # Optional; default shown
 


### PR DESCRIPTION
We've seen a *lot* of transient (and confusing) environment build fails across our org. This switches from miniconda which:
* creates a base env
* updates the base env from the specs in our environment.yml

To [micromamba](https://github.com/mamba-org/provision-with-micromamba) which:
* just creates an environment from our environment yam


I suspect it's the weird env. creation path that minconda does that is causing these issues. And indeed in ASFHyP3/hyp3-gamma#431 pointing the action to this branch does in fact cause the pytest and version info action to succeed.