### PR TITLE
Do not push docker image if repo is a fork

### DIFF
--- a/.github/workflows/reusable-docker-ghcr.yml
+++ b/.github/workflows/reusable-docker-ghcr.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: true
+          push: ! github.event.pull_request.head.repo.fork
           tags: |
             ghcr.io/${{ env.REPO }}:${{ inputs.version_tag }}
           labels: |

--- a/.github/workflows/reusable-docker-ghcr.yml
+++ b/.github/workflows/reusable-docker-ghcr.yml
@@ -59,14 +59,14 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Add test tag
-        if: github.ref == format('refs/heads/{0}', inputs.develop_branch)
+        if: ${{ github.ref == format('refs/heads/{0}', inputs.develop_branch) && ! github.event.pull_request.head.repo.fork }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ghcr.io/${{ env.REPO }}:${{ inputs.version_tag }}
           dst: ghcr.io/${{ env.REPO }}:test
 
       - name: Add latest tag
-        if: github.ref == format('refs/heads/{0}', inputs.release_branch)
+        if: ${{ github.ref == format('refs/heads/{0}', inputs.release_branch) && ! github.event.pull_request.head.repo.fork }}
         uses: akhilerm/tag-push-action@v2.1.0
         with:
           src: ghcr.io/${{ env.REPO }}:${{ inputs.version_tag }}

--- a/.github/workflows/reusable-docker-ghcr.yml
+++ b/.github/workflows/reusable-docker-ghcr.yml
@@ -50,7 +50,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: ! github.event.pull_request.head.repo.fork
+          push: ${{ ! github.event.pull_request.head.repo.fork }}
           tags: |
             ghcr.io/${{ env.REPO }}:${{ inputs.version_tag }}
           labels: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1]
+
+### Fixed
+* [`reusable-docker-ghcr.yml`](.github/workflows/reusable-docker-ghcr.yml) no longer attempts
+  to push a Docker image if run from a fork.
 
 ## [0.7.0]
 


### PR DESCRIPTION
See https://github.com/ASFHyP3/actions/issues/47

This might work based on https://stackoverflow.com/a/70776678/8763290 but I'm still looking for the original documentation on the `fork` field.

Edit: See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request (the Response schema shows the `fork` field at the expected location).