### PR TITLE
Provide option to set failure strategy for pytest workflows

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -10,12 +10,18 @@ on:
           ["3.8", "3.9", "3.10"]
         description: JSON string containing the list of python versions to test
         type: string
+      fail_fast:
+        required: false
+        default: true
+        description: Cancell all in-progress and queued pytest jobs if any job in the matrix fails
+        type: boolean
 
 jobs:
   pytest:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: ${{ inputs.fail_fast }}
       matrix:
         python_version: ${{ fromJson(inputs.python_versions) }}
 

--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -13,7 +13,7 @@ on:
       fail_fast:
         required: false
         default: true
-        description: Cancell all in-progress and queued pytest jobs if any job in the matrix fails
+        description: Cancel all in-progress and queued pytest jobs if any job in the matrix fails
         type: boolean
 
 jobs:

--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -12,7 +12,7 @@ on:
         type: string
       fail_fast:
         required: false
-        default: true
+        default: false
         description: Cancel all in-progress and queued pytest jobs if any job in the matrix fails
         type: boolean
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.8.0]
+
+### Added
+* [`reusable-pytest.yml`](.github/workflows/reusable-pytest.yml) now inlcudes a `fail_fast` option which lets you specify 
+  [the strategy for handling failures](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)
+
 ## [0.7.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.8.0]
 
 ### Added
-* [`reusable-pytest.yml`](.github/workflows/reusable-pytest.yml) now inlcudes a `fail_fast` option which lets you specify 
+* [`reusable-pytest.yml`](.github/workflows/reusable-pytest.yml) now includes a `fail_fast` option which lets you specify 
   [the strategy for handling failures](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)
 
 ## [0.7.1]

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.7.1
     with:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
-      fail_fast: true      # Optional; default shown
+      fail_fast: false      # Optional; default shown
       python_versions: >-  # Optional; default shown
         ["3.8", "3.9", "3.10"]
 ```

--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.7.1
     with:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
-      # Optional; default shown
-      python_versions: >-
+      fail_fast: true      # Optional; default shown
+      python_versions: >-  # Optional; default shown
         ["3.8", "3.9", "3.10"]
 ```
 


### PR DESCRIPTION
If any python version fails, all the other tests are canceled; this allows you to change the strategy such that all pytest jobs will run all the way through.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast