### PR TITLE
Add disclaimer for Jira issue link

### DIFF
--- a/.github/workflows/reusable-create-jira-issue.yml
+++ b/.github/workflows/reusable-create-jira-issue.yml
@@ -44,6 +44,9 @@ jobs:
         uses: actions-cool/issues-helper@v3
         with:
           actions: update-issue
-          body: "**Jira:** ${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }}\n\
-            <!-- The previous line was added by GitHub Actions. It should remain as the first line in this description. -->\n\n\
+          body: "<!-- WARNING: The following lines were added by create-jira-issue, please do not modify! -->\n\
+            **Jira:** ${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }}\n\n\
+            *Note: The above link is accessible only to members of ASF.*\n\n\
+            ----------------------------------------------------------------------------------------------------\n\
+            <!-- WARNING: The preceding lines were added by create-jira-issue, please do not modify! -->\n\n\
             ${{ github.event.issue.body }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1]
+
+### Added
+* Modified [`reusable-create-jira-issue.yml`](./.github/workflows/reusable-create-jira-issue.yml) to add
+  a disclaimer for the Jira issue link.
 
 ## [0.8.0]
 


### PR DESCRIPTION
Here is an example of what the disclaimer looks like on an actual issue: https://github.com/jtherrmann/github-jira-integration/issues/32