### PR TITLE
Replace provision-with-micromamba

### DIFF
--- a/.github/workflows/reusable-pytest.yml
+++ b/.github/workflows/reusable-pytest.yml
@@ -28,9 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: mamba-org/provision-with-micromamba@v15
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          extra-specs: |
+          environment-file: environment.yml
+          create-args: >-
             python=${{ matrix.python_version }}
 
       - name: Pytest in conda environment

--- a/.github/workflows/reusable-version-info.yml
+++ b/.github/workflows/reusable-version-info.yml
@@ -23,9 +23,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: mamba-org/provision-with-micromamba@v15
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          extra-specs: |
+          environment-file: environment.yml
+          create-args: >-
             python=${{ inputs.python_version }}
 
       - name: set outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.8.2]
 
 ### Changed
-* `reusable-pytest` and `reusable-version-info` now use `setup-micromamba` rather than `provision-with-micromamba`.
+* `reusable-pytest` and `reusable-version-info` now use [`setup-micromamba`](https://github.com/mamba-org/setup-micromamba) rather than `provision-with-micromamba` which has been deprecated.
 
 ## [0.8.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.8.2]
+
+### Changed
+* `reusable-pytest` and `reusable-version-info` now use `setup-micromamba` rather than `provision-with-micromamba`.
+
 ## [0.8.1]
 
 ### Added


### PR DESCRIPTION
The `provision-with-micromamba` action has been deprecated; this PR replaces it with `setup-micromamba`. The changes were made in accordance with the readme here: https://github.com/mamba-org/provision-with-micromamba.