### PR TITLE
Create Ruff reusable action

### DIFF
--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -24,4 +24,4 @@ jobs:
         run: ruff check --select I --output-format=github .
 
       - name: Ruff format check
-        run: ruff format --check .
+        run: ruff format --diff .

--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: 3.x
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -6,17 +6,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install Python
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          python -m pip install ruff
+
       - name: Ruff linting check
         run: ruff check --output-format=github .
+
       - name: Ruff imports check
         run: ruff check --select I --output-format=github .
+
       - name: Ruff format check
         run: ruff format check .

--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -24,4 +24,4 @@ jobs:
         run: ruff check --select I --output-format=github .
 
       - name: Ruff format check
-        run: ruff format check .
+        run: ruff format --check .

--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -1,0 +1,22 @@
+on:
+  workflow_call:
+
+jobs:
+  check-with-ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Ruff linting check
+        run: ruff check --output-format=github .
+      - name: Ruff imports check
+        run: ruff check --select I --output-format=github .
+      - name: Ruff format check
+        run: ruff format check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4]
+
+### Added 
+- `reusable-ruff` workflow for perform linting and static analysis with [Ruff](https://github.com/astral-sh/ruff).
 
 ## [0.8.3]
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.8.4
     with:
       user: tools-bot                # Optional; default shown
       email: UAF-asf-apd@alaska.edu  # Optional; default shown
@@ -57,7 +57,7 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.8.4
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -77,7 +77,7 @@ on:
 
 jobs:
   call-create-jira-issue-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-create-jira-issue.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-create-jira-issue.yml@v0.8.4
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -130,13 +130,13 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.4
     with:
       conda_env_name: hyp3-plugin
 
   call-docker-ecr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.8.4
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       ecr_registry: 845172464411.dkr.ecr.us-west-2.amazonaws.com
@@ -171,13 +171,13 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.4
     with:
       conda_env_name: hyp3-plugin
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.8.4
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       user: ${{ github.actor }}
@@ -198,13 +198,44 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.8.4
     with:
       local_package_names: hyp3_plugin  # Required; comma-seperated list of names that should be considered local to your application
       excludes: hyp3_plugin/ugly.py     # Optional; comma-separated list of glob patterns to exclude from checks
 ```
 
 to ensure the Python code is styled correctly.
+
+### [`reusable-ruff.yml`](./.github/workflows/reusable-ruff.yml)
+
+Runs [Ruff](https://docs.astral.sh/ruff/) to enforce a configurable Python style guide. Use like:
+
+```yaml
+name: Static analysis
+
+on: push
+
+jobs:
+  call-ruff-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.8.4
+```
+
+to ensure the Python code is styled correctly.
+
+To conform to ASFHyP3's Python style add the following to your project's `pyproject.toml`:
+```toml
+[tool.ruff]
+line-length = 120
+src = ["src", "tests"]
+
+[tool.ruff.format]
+indent-style = "space"
+quote-style = "single"
+
+[tool.ruff.lint.isort]
+case-sensitive = true
+lines-after-imports = 2
+```
 
 ### [`reusable-git-object-name.yml`](./.github/workflows/reusable-git-object-name.yml)
 
@@ -226,7 +257,7 @@ on:
 
 jobs:
   call-git-object-name-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.8.4
   
   echo-git-object-name-outputs:
     needs: call-git-object-name-workflow
@@ -256,7 +287,7 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.8.4
 ```
 to ensure a release label is included on any PR to `main`.
 
@@ -280,7 +311,7 @@ on:
 
 jobs:
   call-pytest-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.8.4
     with:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
       fail_fast: false      # Optional; default shown
@@ -309,7 +340,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.8.4
     with:
       release_prefix: HyP3-CI
       release_branch: main      # Optional; default shown
@@ -338,7 +369,7 @@ on:
   
 jobs:
   call-release-checklist-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release-checklist-comment.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-release-checklist-comment.yml@v0.8.4
     permissions:
       pull-requests: write
     with:
@@ -367,7 +398,7 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.8.4
 ```
 to scan every push for secrets.
 
@@ -393,7 +424,7 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.2
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.4
     with:
       python_version: '3.9'        # Optional; default shown
 


### PR DESCRIPTION
[Ruff](https://github.com/astral-sh/ruff) is a crazy fast linting and formatting tool that we think is worth using to perform static analysis checks on our repositories. This PR adds a Ruff reusable action that will check three things:

1. General Ruff linting rules
2. isort-based import order
3. `ruff format` style formating

For posterity, most errors detected by this action can be fixed by running the following three commands in a repository's home directory:

```bash
ruff check --fix .
ruff check --select I --fix .
ruff format .
```

For the action to conform to the Tools team's style preferences, the following lines will need to be add to a project's `pyproject.toml` file:

```toml
[tool.ruff]
line-length = 120
src = ["src", "tests"]

[tool.ruff.format]
indent-style = "space"
quote-style = "single"

[tool.ruff.lint.isort]
case-sensitive = true
lines-after-imports = 2
```