### PR TITLE
Proposed updates to Ruff action

### DIFF
--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -20,8 +20,5 @@ jobs:
       - name: Ruff linting check
         run: ruff check --output-format=github .
 
-      - name: Ruff imports check
-        run: ruff check --select I --output-format=github .
-
       - name: Ruff format check
         run: ruff format --diff .

--- a/README.md
+++ b/README.md
@@ -232,9 +232,26 @@ src = ["src", "tests"]
 indent-style = "space"
 quote-style = "single"
 
+[tool.ruff.lint]
+extend-select = [
+    "UP",  # pyupgrade
+    "D",   # pydocstyle
+    "ANN", # annotations
+    "PTH", # use-pathlib-pth
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.lint.isort]
 case-sensitive = true
 lines-after-imports = 2
+```
+
+Ruff can automatically fix many linting errors and reformat code to match your Python style by running these  commands:
+```shell
+ruff check --fix .
+ruff format .
 ```
 
 ### [`reusable-git-object-name.yml`](./.github/workflows/reusable-git-object-name.yml)


### PR DESCRIPTION
* By using `extend-select`, we don't need to run `ruff` check twice
* Adds info to README on how to go about fixing linting/formatting errors
* Adds checks for:
  * [`UP`](https://docs.astral.sh/ruff/rules/#pyupgrade-up): upgrade syntax for newer versions of Python
  * [`D`](https://docs.astral.sh/ruff/rules/#pydocstyle-d): google-style docstrings on all public methods
  * [`ANN`](https://docs.astral.sh/ruff/rules/#flake8-annotations-ann): use of type annotations
  * [`PTH`](https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth): prefer `pathlib` over `os.path`
  
  which are all informal best practices on the team but not previously strictly enforced. 
  
Notably, the additional checks will significantly increase the work required to align our code with this action. All work that I think is worth doing, but I'm def. open to pushback, or incrementally adding these checks.

To reduce the work required to migrate a code base, Ruff provides a way to add `noqa` statements to existing issues and only be strict with new issues: https://docs.astral.sh/ruff/tutorial/#adding-rules

That might be a good path forward for especially hyp3-gamma, but I'd be inclined to try and fix everything if possible and only fall back to `noqa` if it's too hard to switch.

See ASFHyP3/hyp3-isce2#156 for and example of what these additional checks would look like. 