### PR TITLE
Add workflow to update version in README

### DIFF
--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -1,0 +1,50 @@
+name: Update Actions Examples
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  call-git-object-name-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.8.4
+
+  upate_actions_examples:
+    needs: call-git-object-name-workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.TOOLS_BOT_PAK }}
+
+      - name: Create update branch
+        id: update
+        env:
+          ACTIONS_VERSION: ${{ needs.call-git-object-name-workflow.outputs.name }}
+          UPDATE_BRANCH: update-examples-to-${{ needs.call-git-object-name-workflow.outputs.name }}
+        run: |
+          git config user.name "tools-bot"
+          git config user.email "UAF-asf-apd@alaska.edu"
+          
+          echo "::set-output name=branch::${UPDATE_BRANCH}"
+          git checkout -b ${UPDATE_BRANCH}
+          
+          export SEARCH_PATTERN='(ASFHyP3/actions/.github/workflows/.*.yml)@v[0-9]+\.[0-9]+\.[0-9]+'
+          sed -i -r "s|$SEARCH_PATTERN|\1@${ACTIONS_VERSION}|g" README.md
+          
+          git commit -am "Bump actions example's version to ${ACTIONS_VERSION}"
+          git push origin ${UPDATE_BRANCH}
+
+      - name: open PR
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch:  ${{ steps.update.outputs.branch }}
+          destination_branch: develop
+          pr_title: Update Actions example versions to ${{ needs.call-git-object-name-workflow.outputs.name }}
+          pr_body: |
+            PR created by a new `v*` tag push event
+          pr_assignee: ASFHyP3/tools
+          pr_label: tools-bot
+          pr_draft: false
+          pr_allow_empty: true
+          github_token: ${{ secrets.TOOLS_BOT_PAK }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.8.4]
 
 ### Added 
-- `reusable-ruff` workflow for perform linting and static analysis with [Ruff](https://github.com/astral-sh/ruff).
+- [`reusable-ruff`](.github/workflows/reusable-ruff.yml) reusable workflow for perform linting and static analysis with [Ruff](https://github.com/astral-sh/ruff).
+- [`update-examples`](.github/workflows/update-examples.yml) workflow to keep the pinned version number in the README examples up to date
 
 ## [0.8.3]
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.8.3
     with:
       user: tools-bot                # Optional; default shown
       email: UAF-asf-apd@alaska.edu  # Optional; default shown
@@ -57,7 +57,7 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.8.3
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -77,7 +77,7 @@ on:
 
 jobs:
   call-create-jira-issue-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-create-jira-issue.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-create-jira-issue.yml@v0.8.3
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
@@ -130,13 +130,13 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.3
     with:
       conda_env_name: hyp3-plugin
 
   call-docker-ecr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.8.3
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       ecr_registry: 845172464411.dkr.ecr.us-west-2.amazonaws.com
@@ -171,13 +171,13 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.3
     with:
       conda_env_name: hyp3-plugin
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.8.3
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       user: ${{ github.actor }}
@@ -198,7 +198,7 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.8.3
     with:
       local_package_names: hyp3_plugin  # Required; comma-seperated list of names that should be considered local to your application
       excludes: hyp3_plugin/ugly.py     # Optional; comma-separated list of glob patterns to exclude from checks
@@ -217,7 +217,7 @@ on: push
 
 jobs:
   call-ruff-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.8.3
 ```
 
 to ensure the Python code is styled correctly.
@@ -274,7 +274,7 @@ on:
 
 jobs:
   call-git-object-name-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-git-object-name.yml@v0.8.3
   
   echo-git-object-name-outputs:
     needs: call-git-object-name-workflow
@@ -304,7 +304,7 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.8.3
 ```
 to ensure a release label is included on any PR to `main`.
 
@@ -328,7 +328,7 @@ on:
 
 jobs:
   call-pytest-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.8.3
     with:
       local_package_name: hyp3_plugin  # Required; package to produce a coverage report for
       fail_fast: false      # Optional; default shown
@@ -357,7 +357,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.8.3
     with:
       release_prefix: HyP3-CI
       release_branch: main      # Optional; default shown
@@ -386,7 +386,7 @@ on:
   
 jobs:
   call-release-checklist-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release-checklist-comment.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-release-checklist-comment.yml@v0.8.3
     permissions:
       pull-requests: write
     with:
@@ -415,7 +415,7 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.8.3
 ```
 to scan every push for secrets.
 
@@ -441,7 +441,7 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.4
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.8.3
     with:
       python_version: '3.9'        # Optional; default shown
 


### PR DESCRIPTION
In #94, the ASFHyP3/actions version number used in the README examples was bumped to the next expected version, but that version has not yet been released, so none of the examples in the default branch's README currently work. 

A similar issue occurs when we release and then don't circle back to update the example version, causing our examples to lag behind the latest release.

We can "fix" this by more rapidly releasing, but either way, there's a manual version update step that is *annoying*. 

**This** adds a GitHub Action workflow to change all the examples in the README to use the latest version tag anytime a new tag is pushed. 

I've used the `sed` command in this action to reset the version numbers in the README to the current release version so we can watch it in action.

---

Technically, the README for the specific tag will still always be 1 version behind, but since we don't typically *know* the version number until the release PR, this is the simplest way to automatically keep the default branch's README,  which is the default docs, up to date

We *could* trigger this workflow instead on PRs to `main` and use `bump2version` like in our release workflow to predict the next version based on the PR labels, but we'd (1) have to push directly to `develop` and (2) handle label changes. 

All of which is manageable but seems more complicated than necessary... 