### PR TITLE
Update trufflehog action

### DIFF
--- a/.github/workflows/reusable-secrets-analysis.yml
+++ b/.github/workflows/reusable-secrets-analysis.yml
@@ -2,25 +2,14 @@ on:
   workflow_call
 
 jobs:
-  trufflehog:
+  trufflehog:  
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - name: Secret Scanning
+        uses: trufflesecurity/trufflehog@v3.63.8
         with:
-          python-version: 3.x
-
-      - name: Pip install trufflehog
-        shell: bash
-        run: |
-          python -m pip install trufflehog
-
-      - name: Scan for secrets with trufflehog
-        shell: bash
-        run: |
-          export LAST_TAG_HASH=$(git rev-list -1 $(git describe --abbrev=0))
-          trufflehog --regex --entropy True --since_commit "${LAST_TAG_HASH}" \
-              --exclude_paths .trufflehog.txt file://"${PWD}"
+          extra_args: --only-verified --exclude_paths .trufflehog.txt

--- a/.github/workflows/reusable-secrets-analysis.yml
+++ b/.github/workflows/reusable-secrets-analysis.yml
@@ -2,7 +2,7 @@ on:
   workflow_call
 
 jobs:
-  trufflehog:  
+  trufflehog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reusable-secrets-analysis.yml
+++ b/.github/workflows/reusable-secrets-analysis.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@v3.63.8
         with:
-          extra_args: --only-verified --exclude_paths .trufflehog.txt
+          extra_args: --only-verified

--- a/.github/workflows/reusable-secrets-analysis.yml
+++ b/.github/workflows/reusable-secrets-analysis.yml
@@ -12,4 +12,5 @@ jobs:
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@v3.63.8
         with:
+          base: main
           extra_args: --only-verified

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,4 +4,4 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.9.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@jhkennedy-patch-1

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,4 +4,4 @@ on: push
 
 jobs:
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.10.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@jhkennedy-patch-1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.1]
+## [0.11.0]
 
 ### Fixed
 - [`update-examples`](.github/workflows/update-examples.yml) workflow will now strip distance and hash (longest `-*` match) from the input or calculated version numbers.
+- [`reusable-secrets-analysis.yml`](.github/workflows/reusable-secrets-analysis.yml) now uses the Trufflehog Github Action to scan for only verified secrets, which should reduce or eliminate false positives.
+
+### Removed
+- [`reusable-secrets-analysis.yml`](.github/workflows/reusable-secrets-analysis.yml) no longer recognizes `.trufflehog.txt`, which was previously used to specify exclude paths.
 
 ## [0.10.0]
 


### PR DESCRIPTION
Our current action uses `trufflehog` v2, but v3 has been out for some time: https://github.com/trufflesecurity/trufflehog

We're not getting the latest version because it was re-written in go and no longer distributed on PyPI or conda-forge. 

This PR switches the trufflhog reusable workflow over to using the GitHub Action they provide. 

A major benefit of the v3 upgrade is they now have a secret verification API so we should see significantly reduced false positives. 
