### PR TITLE
Implement changelog check without third-party action

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,4 +11,6 @@ on:
       - develop
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.0
+    # TODO revert pin
+    #uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@changelog-check

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,6 +11,4 @@ on:
       - develop
 jobs:
   call-changelog-check-workflow:
-    # TODO revert pin
-    #uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.0
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@changelog-check
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,5 +12,3 @@ on:
 jobs:
   call-changelog-check-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.10.0
-    secrets:
-      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-changelog-check.yml
+++ b/.github/workflows/reusable-changelog-check.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Changelog check
-        run: '! git diff --quiet ${{ github.event.pull_request.base.ref }} -- CHANGELOG.md'
+        run: '! git diff --quiet "origin/${{ github.event.pull_request.base.ref }}" -- CHANGELOG.md'
         shell: bash

--- a/.github/workflows/reusable-changelog-check.yml
+++ b/.github/workflows/reusable-changelog-check.yml
@@ -8,5 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Changelog check
-        run: ! git diff --quiet CHANGELOG.md
+        run: '! git diff --quiet CHANGELOG.md'
         shell: bash

--- a/.github/workflows/reusable-changelog-check.yml
+++ b/.github/workflows/reusable-changelog-check.yml
@@ -8,5 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Changelog check
-        run: '! git diff --quiet CHANGELOG.md'
+        run: '! git diff --quiet "origin/${{ github.event.pull_request.base.ref }}" -- CHANGELOG.md'
         shell: bash

--- a/.github/workflows/reusable-changelog-check.yml
+++ b/.github/workflows/reusable-changelog-check.yml
@@ -8,5 +8,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Changelog check
-        run: '! git diff --quiet "origin/${{ github.event.pull_request.base.ref }}" -- CHANGELOG.md'
+        run: '! git diff --quiet ${{ github.event.pull_request.base.ref }} -- CHANGELOG.md'
         shell: bash

--- a/.github/workflows/reusable-changelog-check.yml
+++ b/.github/workflows/reusable-changelog-check.yml
@@ -1,19 +1,12 @@
 on:
   workflow_call:
-    secrets:
-      USER_TOKEN:
-        required: true
 
 jobs:
   changelog-updated:
+    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'bumpless') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Changelog check
-        uses: Zomzog/changelog-checker@v1.3.0
-        with:
-          fileName: CHANGELOG.md
-          noChangelogLabel: bumpless
-        env:
-          GITHUB_TOKEN: ${{ secrets.USER_TOKEN }}
+        run: ! git diff --quiet CHANGELOG.md
+        shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1]
+
+### Fixed
+- Modified the [`reusable-changelog-check`](.github/workflows/reusable-changelog-check.yml) workflow to remove its dependency on a third-party action. The workflow behavior should remain unchanged except that applying the `bumpless` label now results in the workflow being skipped rather than succeeding. Fixes https://github.com/ASFHyP3/actions/issues/156
+
 ## [0.11.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Modified the [`reusable-changelog-check`](.github/workflows/reusable-changelog-check.yml) workflow to remove its dependency on a third-party action. The workflow behavior should remain unchanged except that applying the `bumpless` label now results in the workflow being skipped rather than succeeding. Fixes https://github.com/ASFHyP3/actions/issues/156
-  - When upgrading this reusable action in your repository, you can remove the following lines from the calling workflow:
+  - When upgrading this reusable action in your repository, remove the following lines from the calling workflow:
     ```diff
     -    secrets:
     -      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - Modified the [`reusable-changelog-check`](.github/workflows/reusable-changelog-check.yml) workflow to remove its dependency on a third-party action. The workflow behavior should remain unchanged except that applying the `bumpless` label now results in the workflow being skipped rather than succeeding. Fixes https://github.com/ASFHyP3/actions/issues/156
+  - When upgrading this reusable action in your repository, you can remove the following lines from the calling workflow:
+    ```diff
+    -      secrets:
+    -      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    ```
 
 ## [0.11.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified the [`reusable-changelog-check`](.github/workflows/reusable-changelog-check.yml) workflow to remove its dependency on a third-party action. The workflow behavior should remain unchanged except that applying the `bumpless` label now results in the workflow being skipped rather than succeeding. Fixes https://github.com/ASFHyP3/actions/issues/156
   - When upgrading this reusable action in your repository, you can remove the following lines from the calling workflow:
     ```diff
-    -      secrets:
+    -    secrets:
     -      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     ```
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ on:
 jobs:
   call-changelog-check-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.10.0
-    secrets:
-      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 to ensure the changelog has been updated for any PR to `develop` or `main`. 


### PR DESCRIPTION
Example of failure (changelog not updated): https://github.com/ASFHyP3/actions/actions/runs/9508129627/job/26208873490?pr=157

Example of skipped (`bumpless` label applied): https://github.com/ASFHyP3/actions/actions/runs/9508137239/job/26208898220?pr=157

Example of success (changelog updated): https://github.com/ASFHyP3/actions/actions/runs/9508188984/job/26209030351?pr=157