### PR TITLE
Notify HyP3 Cookiecutter of new actions

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -1,0 +1,19 @@
+name: Notify Downstream of New Release
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bump Actions version in HyP3 Cookiecutter
+        uses: benc-uk/workflow-dispatch@v1.2
+        with:
+          workflow: update_actions_version.yml
+          token: ${{ secrets.TOOLS_BOT_PAK }}
+          repo: ASFHyP3/hyp3-cookiecutter
+          ref: develop
+          inputs: '{"version": "${{ github.event.release.tag_name }}"}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0]
+### Added
+- Releases of ASFHyP3/actions will now trigger updates to the ASFHyP3/hyp3-cookiecutter
+
 ## [0.11.2]
 
 ### Changed


### PR DESCRIPTION
Following the pattern we use for [updating hyp3_sdk/asf_tools docs](https://github.com/ASFHyP3/hyp3-sdk/blob/develop/.github/workflows/notify-downstream.yml) in [hyp3-docs](https://github.com/ASFHyP3/hyp3-docs/blob/develop/.github/workflows/update_sdk_version.yml) and [updating the actions version in the actions README examples](https://github.com/ASFHyP3/actions/blob/develop/.github/workflows/update-examples.yml), this:
*  adds a workflow that, upon release, will trigger the hyp3-cookiecutter to update all the ASFHyP3/actions used in the template. The triggered workflow has been added to the repository, is already available on the default branch, and is described in ASFHyP3/hyp3-cookiecutter#66

