### PR TITLE
remove repo-sync/pull-request in favor of gh pr create

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -30,10 +30,11 @@ jobs:
           token: ${{ secrets.USER_TOKEN }}
 
       - name: Create Release
-        uses: anton-yurchenko/git-release@v6.0.0
+        uses: docker://antonyurchenko/git-release:v3.5.0
         env:
           GITHUB_TOKEN: ${{ secrets.USER_TOKEN }}
           RELEASE_NAME_PREFIX: "${{ inputs.release_prefix }} "
+          ALLOW_TAG_PREFIX: true
 
       - name: Attempt fast-forward develop from release
         run: |

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -43,7 +43,7 @@ jobs:
           git merge --ff-only origin/${{ inputs.release_branch }}
           git push
 
-      - name: On failure, Open PR to bring release back to develop
+      - name: On failure, open PR to bring release back to develop
         if: ${{ failure() }}
         env:
           PR_TITLE: Pulling ${{ github.ref }} into ${{ inputs.develop_branch }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -44,15 +44,14 @@ jobs:
           git push
 
       - name: Open PR to bring release back to develop
-        if: ${{ failure() }}
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: ${{ inputs.release_branch }}
-          destination_branch: ${{ inputs.develop_branch }}
-          pr_title: Pulling ${{ github.ref }} into ${{ inputs.develop_branch }}
-          pr_body: Fast-forward of ${{ inputs.release_branch }} to ${{ inputs.develop_branch }} failed!
-          pr_assignee: ${{ github.actor }}
-          pr_label: ${{ inputs.sync_pr_label }}
-          pr_draft: false
-          pr_allow_empty: true
-          github_token: ${{ secrets.USER_TOKEN }}
+        env:
+          PR_TITLE: Pulling ${{ github.ref }} into ${{ inputs.develop_branch }}
+          PR_BODY: Fast-forward of ${{ inputs.release_branch }} to ${{ inputs.develop_branch }} failed!
+          GH_TOKEN: ${{ secrets.USER_TOKEN }}
+        run: |
+          gh pr create -t "${PR_TITLE}" \
+                      -b "${PR_BODY}" \
+                      -a ${{ github.actor }} \
+                      -l ${{ inputs.sync_pr_label }} \
+                      -H ${{ inputs.release_branch }} \
+                      -B ${{ inputs.develop_branch }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -50,9 +50,9 @@ jobs:
           PR_BODY: Fast-forward of ${{ inputs.release_branch }} to ${{ inputs.develop_branch }} failed!
           GH_TOKEN: ${{ secrets.USER_TOKEN }}
         run: |
-          gh pr create -t "${PR_TITLE}" \
-                      -b "${PR_BODY}" \
-                      -a ${{ github.actor }} \
-                      -l ${{ inputs.sync_pr_label }} \
-                      -H ${{ inputs.release_branch }} \
-                      -B ${{ inputs.develop_branch }}
+          gh pr create --title "${PR_TITLE}" \
+                      --body "${PR_BODY}" \
+                      --assignee ${{ github.actor }} \
+                      --label ${{ inputs.sync_pr_label }} \
+                      --head ${{ inputs.release_branch }} \
+                      --base ${{ inputs.develop_branch }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -43,7 +43,8 @@ jobs:
           git merge --ff-only origin/${{ inputs.release_branch }}
           git push
 
-      - name: Open PR to bring release back to develop
+      - name: On failure, Open PR to bring release back to develop
+        if: ${{ failure() }}
         env:
           PR_TITLE: Pulling ${{ github.ref }} into ${{ inputs.develop_branch }}
           PR_BODY: Fast-forward of ${{ inputs.release_branch }} to ${{ inputs.develop_branch }} failed!

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -30,11 +30,10 @@ jobs:
           token: ${{ secrets.USER_TOKEN }}
 
       - name: Create Release
-        uses: docker://antonyurchenko/git-release:v3.5.0
+        uses: anton-yurchenko/git-release@v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.USER_TOKEN }}
           RELEASE_NAME_PREFIX: "${{ inputs.release_prefix }} "
-          ALLOW_TAG_PREFIX: true
 
       - name: Attempt fast-forward develop from release
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1]
+### Fixed
+- The [`reusable-release-action`](.github/workflows/reusable-release.yml) no longer uses the deprecated, archived, and broken `repo-sync/pull-request` action.
+
 ## [0.12.0]
 ### Added
 - Releases of ASFHyP3/actions will now trigger updates to the ASFHyP3/hyp3-cookiecutter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.12.1]
 ### Fixed
-- The [`reusable-release-action`](.github/workflows/reusable-release.yml) no longer uses the deprecated, archived, and broken `repo-sync/pull-request` action.
+- The [`reusable-release-action`](.github/workflows/reusable-release.yml) now uses the `gh` CLI instead of the archived `repo-sync/pull-request` action.
 
 ## [0.12.0]
 ### Added


### PR DESCRIPTION
Note: `pr_allow_empty: true` used in repo-sync/pull-request has no analog in the `gh` CLI , likely didn't ever work, and shouldn't be needed:
https://github.com/cli/cli/issues/9112

fixes #106 