### PR TITLE
Revert `ruff` imports option

### DIFF
--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -18,7 +18,7 @@ jobs:
           python -m pip install ruff
 
       - name: Ruff linting check
-        run: ruff check --select I --output-format=github . || echo 'To automatically fix errors, run `ruff check --select I --fix .`'
+        run: ruff check --output-format=github . || echo 'To automatically fix errors, run `ruff check --fix .`'
 
       - name: Ruff format check
         run: ruff format --diff . || echo 'To automatically fix errors, run `ruff format .`'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1]
+
+### Changed
+- Reverts the addition of `--select I` to [`reusable-ruff`](.github/workflows/reusable-ruff.yml), as this option is already included in the recommended `pyproject.toml` settings given in the README.
+
 ## [0.13.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ jobs:
 Make sure that `pyproject.toml` contains the appropriate Python version specifier
 (see the [ruff docs](https://docs.astral.sh/ruff/settings/#target-version)), e.g:
 
-```
+```toml
 [project]
 requires-python = ">=3.13"
 ```

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ To conform to ASFHyP3's Python style add the following to your project's `pyproj
 ```toml
 [tool.ruff]
 line-length = 120
+# The directories to consider when resolving first- vs. third-party imports.
+# See: https://docs.astral.sh/ruff/settings/#src
 src = ["src", "tests"]
 
 [tool.ruff.format]
@@ -257,12 +259,6 @@ convention = "google"
 [tool.ruff.lint.isort]
 case-sensitive = true
 lines-after-imports = 2
-```
-
-Ruff can automatically fix many linting errors and reformat code to match your Python style by running these  commands:
-```shell
-ruff check --fix .
-ruff format .
 ```
 
 ### [`reusable-git-object-name.yml`](./.github/workflows/reusable-git-object-name.yml)

--- a/README.md
+++ b/README.md
@@ -230,9 +230,17 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.12.0
 ```
 
-to ensure the Python code is styled correctly.
+Make sure that `pyproject.toml` contains the appropriate Python version specifier
+(see the [ruff docs](https://docs.astral.sh/ruff/settings/#target-version)), e.g:
 
-To conform to ASFHyP3's Python style add the following to your project's `pyproject.toml`:
+```
+[project]
+requires-python = ">=3.13"
+```
+
+To conform to ASFHyP3's Python style add the following to `pyproject.toml`
+(and update the `src =` line as needed, for import ordering):
+
 ```toml
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
TODO:

- [x] We currently specify `python-version: 3.x` in the ruff reusable action. How is the exact version resolved? Should we allow passing the version to the ruff reusable action so that repos can specify their specific version?