### PR TITLE
remove mypy cli options

### DIFF
--- a/.github/workflows/reusable-mypy.yml
+++ b/.github/workflows/reusable-mypy.yml
@@ -14,4 +14,4 @@ jobs:
       - name: Check with MyPy
         shell: bash -l {0}
         run: |
-          mkdir .mypy_cache && mypy --install-types --ignore-missing-imports --non-interactive --pretty .
+          mkdir .mypy_cache && mypy .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0]
+
+### Removed
+- The [`reusable-mypy`](.github/workflows/reusable-mypy.yml) workflow no longer passes any optional arguments to the `mypy` command. If you want to preserve these options, you must now add them to `[tool.mypy]` in `pyproject.toml`:
+  ```toml
+  install_types = true
+  non_interactive = true
+  pretty = true
+  ignore_missing_imports = true
+  ```
+  Note that we discourage enabling `ignore_missing_imports` as a global option (see <https://github.com/ASFHyP3/actions/issues/225>). You can always find our currently recommended configuration options in the [README](https://github.com/ASFHyP3/actions#reusable-mypyyml).
+
 ## [0.14.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.15.0]
 
 ### Removed
-- The [`reusable-mypy`](.github/workflows/reusable-mypy.yml) workflow no longer passes any optional arguments to the `mypy` command. If you want to preserve these options, you must now add them to `[tool.mypy]` in `pyproject.toml`:
+- The [`reusable-mypy`](.github/workflows/reusable-mypy.yml) workflow no longer passes any optional arguments to the `mypy` command. This makes it easier to run `mypy` locally, because the command is now just `mypy .`. If you want to preserve the removed options for your project, you must now add them to `[tool.mypy]` in `pyproject.toml`:
   ```toml
   install_types = true
   non_interactive = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,21 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.15.0]
 
 ### Removed
-- The [`reusable-mypy`](.github/workflows/reusable-mypy.yml) workflow no longer passes any optional arguments to the `mypy` command. This makes it easier to run `mypy` locally, because the command is now just `mypy .`. If you want to preserve the removed options for your project, you must now add them to `[tool.mypy]` in `pyproject.toml`:
+- The [`reusable-mypy`](.github/workflows/reusable-mypy.yml) workflow no longer passes any optional arguments to the `mypy` command. This makes it easier to run `mypy` locally, because the command is just:
+
+  ```
+  mypy .
+  ```
+
+  If you want to preserve the removed options for your project, you must now add them to `[tool.mypy]` in `pyproject.toml`:
+
   ```toml
   install_types = true
   non_interactive = true
   pretty = true
   ignore_missing_imports = true
   ```
+
   Note that we discourage enabling `ignore_missing_imports` as a global option (see <https://github.com/ASFHyP3/actions/issues/225>). You can always find our currently recommended configuration options in the [README](https://github.com/ASFHyP3/actions#reusable-mypyyml).
 
 ## [0.14.0]

--- a/README.md
+++ b/README.md
@@ -274,6 +274,9 @@ warn_unused_ignores = true
 warn_unreachable = true
 strict_equality = true
 check_untyped_defs = true
+install_types = true
+non_interactive = true
+pretty = true
 ```
 
 Populate the
@@ -293,6 +296,9 @@ requires-python = ">=3.10"
 [tool.mypy]
 python_version = "3.10"
 ```
+
+Note that you may need to enable additional options depending on the needs of your project.
+See our [Mypy](https://github.com/ASFHyP3/.github-private/wiki/Mypy) wiki article for configuration tips.
 
 ### [`reusable-git-object-name.yml`](./.github/workflows/reusable-git-object-name.yml)
 


### PR DESCRIPTION
This makes it easier to run `mypy` locally.

See https://github.com/ASFHyP3/actions/issues/225 for context on no longer recommending `ignore_missing_imports`.

This PR is ready and approved, but @forrestfwilliams wants to discuss further.