### PR TITLE
Track upstream branch in update examples

### DIFF
--- a/.github/workflows/update-examples.yml
+++ b/.github/workflows/update-examples.yml
@@ -47,7 +47,7 @@ jobs:
           sed -i -r "s|$SEARCH_PATTERN|\1@${ACTIONS_VERSION}|g" README.md
           
           git commit -am "Bump actions example's version to ${ACTIONS_VERSION}"
-          git push origin ${UPDATE_BRANCH}
+          git push -u origin ${UPDATE_BRANCH}
 
       - name: Open PR
         env:


### PR DESCRIPTION
The update examples action fails because `gh pr` doesn't know which remote branch to use. Simply tracking the upstream branch when we push the proposed changes is sufficient for `gh pr`, or, we could explicitly set `--head origin/BRANCH_NAME`. I prefer the former.

You can see a successful run of the Update Examples action in https://github.com/ASFHyP3/actions/pull/233 which was created from this PR (https://github.com/ASFHyP3/actions/pull/231/commits/908563c16cb02740340c900777c78dad0c8d6d48, specifically). 

fixes #229 