### PR TITLE
Run ruff format even if ruff check failed

### DIFF
--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -21,4 +21,5 @@ jobs:
         run: ruff check --output-format=github || (echo 'Run `ruff check --fix` to automatically fix errors where possible.' && exit 1)
 
       - name: ruff format
+        if: ${{ !cancelled() }}
         run: ruff format --diff || (echo 'Run `ruff format` to automatically re-format.' && exit 1)


### PR DESCRIPTION
I'd generally prefer to know if either ruff linting _or_ formatting will fail so I can resolve all ruff issues simultaneously. Right now, however, if `ruff check` fails, `ruff format` won't be run, which can lead to multiple cycles to address this check. 

Relevant GitHub docs:
* https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always
* https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error

Note: `continue-on-error: true` would mean failures would be counted as successes and is not what we'd want here. This will still be considered a workflow failure. 