### PR TITLE
Run ruff inside mamba environment, sync ruff settings with hyp3-cookiecutter

### DIFF
--- a/.github/workflows/reusable-ruff.yml
+++ b/.github/workflows/reusable-ruff.yml
@@ -7,15 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Python
-        uses: actions/setup-python@v5
+      - uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: 3.x
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install ruff
+          environment-file: environment.yml
 
       - name: ruff check
         run: ruff check --output-format=github || (echo 'Run `ruff check --fix` to automatically fix errors where possible.' && exit 1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.17.0]
 
 ### Changed
-- The [`reusable-ruff`](.github/workflows/reusable-ruff.yml) workflow now runs inside a mamba environment and assumes the presence of a `environment.yml` file.
+- The [`reusable-ruff`](.github/workflows/reusable-ruff.yml) workflow now runs inside a mamba environment and assumes the presence of an `environment.yml` file.
 - We now recommend pinning to an exact version for both `ruff` and `mypy` in your project dependencies, to avoid unexpected static analysis errors due to unpinned dependency upgrades.
 - We now recommend adding the following lines to `pyproject.toml`, to bring our recommended `ruff` settings in line with [hyp3-cookiecutter](https://github.com/ASFHyP3/hyp3-cookiecutter/blob/v0.3.3/%7B%7Bcookiecutter.__project_name%7D%7D/pyproject.toml#L56-L84):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0]
+
+### Changed
+- The [`reusable-ruff`](.github/workflows/reusable-ruff.yml) workflow now runs inside a mamba environment and assumes the presence of a `environment.yml` file.
+- We now recommend pinning to an exact version for both `ruff` and `mypy` in your project dependencies, to avoid unexpected static analysis errors due to unpinned dependency upgrades.
+- We now recommend adding the following lines to `pyproject.toml`, to bring our recommended `ruff` settings in line with [hyp3-cookiecutter](https://github.com/ASFHyP3/hyp3-cookiecutter/blob/v0.3.3/%7B%7Bcookiecutter.__project_name%7D%7D/pyproject.toml#L56-L84):
+
+    ```toml
+    [tool.ruff.lint.extend-per-file-ignores]
+    "tests/*" = ["D100", "D103", "ANN"]
+    ```
+
 ## [0.16.0]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -208,8 +208,12 @@ on: push
 
 jobs:
   call-ruff-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.16.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.17.0
 ```
+
+Runs inside a mamba environment and assumes the presence of an `environment.yml` file.
+We recommend pinning to an exact version of `ruff` in your project dependencies,
+because upgrading `ruff` may result in new errors being reported by the `check` and `format` commands.
 
 Make sure that `pyproject.toml` contains the appropriate Python version specifier
 (see the [ruff docs](https://docs.astral.sh/ruff/settings/#target-version)), e.g:
@@ -250,6 +254,9 @@ convention = "google"
 [tool.ruff.lint.isort]
 case-sensitive = true
 lines-after-imports = 2
+
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/*" = ["D100", "D103", "ANN"]
 ```
 
 ### [`reusable-mypy.yml`](./.github/workflows/reusable-mypy.yml)
@@ -263,8 +270,12 @@ on: push
 
 jobs:
   call-mypy-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@v0.16.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@v0.17.0
 ```
+
+Runs inside a mamba environment and assumes the presence of an `environment.yml` file.
+We recommend pinning to an exact version of `mypy` in your project dependencies,
+because upgrading `mypy` may result in new type errors being reported.
 
 To use our recommended configuration options, add the following to `pyproject.toml`:
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ jobs:
 
 Runs inside a mamba environment and assumes the presence of an `environment.yml` file.
 We recommend pinning to an exact version of `ruff` in your project dependencies,
-because upgrading `ruff` may result in new errors being reported by the `check` and `format` commands.
+because upgrading `ruff` may result in new static analysis errors being reported.
 
 Make sure that `pyproject.toml` contains the appropriate Python version specifier
 (see the [ruff docs](https://docs.astral.sh/ruff/settings/#target-version)), e.g:


### PR DESCRIPTION
`ruff` doesn't need to run inside the mamba environment, but I can't think of a better way to allow pinning `ruff` on a per-repo basis, aside from having a separate `requirements-ruff.txt` file just for `ruff`. But I'm open to suggestions for how to do this without building the mamba environment.