### PR TITLE
remove create-issue step of reusable-create-jira-issue workflow

### DIFF
--- a/.github/workflows/reusable-create-jira-issue.yml
+++ b/.github/workflows/reusable-create-jira-issue.yml
@@ -39,14 +39,3 @@ jobs:
           summary: ${{ github.event.issue.title }}
           description: ${{ github.event.issue.html_url }}
           fields: '${{ secrets.JIRA_FIELDS }}'
-
-      - name: Add Jira issue key to GitHub issue body
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: update-issue
-          body: "<!-- WARNING: The following lines were added by create-jira-issue, please do not modify! -->\n\
-            **Jira:** ${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }}\n\n\
-            *Note: The above link is accessible only to members of ASF.*\n\n\
-            ----------------------------------------------------------------------------------------------------\n\
-            <!-- WARNING: The preceding lines were added by create-jira-issue, please do not modify! -->\n\n\
-            ${{ github.event.issue.body }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.21.1]
+
+### Added
+- The `reusable-create-jira-issue` workflow no longer updated the github issue with a link to the jira issue. Fixes #328.
+
 ## [0.21.0]
 
 ### Added


### PR DESCRIPTION
Fixes #328 