### PR TITLE
Update reusable actions to use OIDC

### DIFF
--- a/.github/workflows/reusable-docker-ecr.yml
+++ b/.github/workflows/reusable-docker-ecr.yml
@@ -15,11 +15,6 @@ on:
         required: false
         default: Dockerfile
         type: string
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
 
 concurrency:
   group: ${{ inputs.version_tag }}
@@ -28,6 +23,7 @@ concurrency:
 jobs:
   dockerize:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,14 +33,14 @@ jobs:
         run: |
           echo "CI_JOB_TIMESTAMP=$(date --utc --rfc-3339=seconds)" >> $GITHUB_ENV
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{env.AWS_DEFAULT_REGION}}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-
-      - uses: aws-actions/configure-aws-credentials@v6
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ inputs.aws_region }}
 
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2

--- a/README.md
+++ b/README.md
@@ -174,15 +174,15 @@ jobs:
     needs: call-version-info-workflow
     uses: ASFHyP3/actions/.github/workflows/reusable-docker-ecr.yml@v0.21.1
     permissions:
+      id-token: write
       contents: read
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       ecr_registry: 845172464411.dkr.ecr.us-west-2.amazonaws.com
       aws_region: us-west-2    # Optional; default shown
-      file: Dockerfile         # Optional; default shown
+      file: Dockerfile         # Optional; default show
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
 ```
 
 ### [`reusable-docker-ghcr.yml`](./.github/workflows/reusable-docker-ghcr.yml)


### PR DESCRIPTION
This is only for reusable docker workflow, but this doesn't seem to be used anywhere, so this could also be a PR to retire it. 